### PR TITLE
Fix: GenerateNextValue progress should never go above 1.0f

### DIFF
--- a/Source/friz/curves/parametric.cpp
+++ b/Source/friz/curves/parametric.cpp
@@ -348,10 +348,14 @@ void Parametric::SetCurve (CurveFn curve)
 
 float Parametric::GenerateNextValue ()
 {
-    float progress   = (1.f * fFrameCount) / (fDuration);
+    float progress   = (float) fFrameCount / (float) fDuration;
     float curvePoint = fCurve (progress) * fDistance;
 
-    if (fEndVal > fStartVal)
+    if (progress >= 1.0f)
+    {
+        return fEndVal;
+    }
+    else if (fEndVal > fStartVal)
     {
         return fStartVal + curvePoint;
     }


### PR DESCRIPTION
Hi there,

This is the only overt bug I ran into. But perhaps I just pushed the framework beyond original intention.

Essentially: Animations can start running backwards if one parameter has a shorter duration than the other. For example:

```
auto fadeInParams = std::make_unique<friz::Parametric> (friz::Parametric::CurveType::kEaseOutSine, 0.0f, 1.0f, 0.3f * 60);
auto dropInParams = std::make_unique<friz::Parametric> (friz::Parametric::CurveType::kEaseOutSine, -10.f, 0.f, 0.5f * 60);
auto fadeInTween = std::make_unique<friz::Animation<2>> (friz::Animation<2>::SourceList { std::move (fadeInParams), std::move (dropInParams) }, 0);
```

What happens is that the shorter one starts running backwards. This PR fixes that by returning `fEndVal` whenever progress reaches 1.0f. It also fixes some implicit int to float warnings in the method. 

I didn't touch the "Original Easings" — it looks like they might exhibit the same issue but I'm not working with those at the moment.
 