### PR TITLE
Replace std::powf with (float) std::pow for gcc compatibility  

### DIFF
--- a/Source/friz/curves/parametric.cpp
+++ b/Source/friz/curves/parametric.cpp
@@ -59,19 +59,19 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
     {
         case kEaseInSine:
         {
-            curve = [=] (float x) { return 1 - std::cosf ((x * kPi) / 2); };
+            curve = [=] (float x) { return 1 - (float) std::cos ((x * kPi) / 2); };
         }
         break;
 
         case kEaseOutSine:
         {
-            curve = [=] (float x) { return std::sinf (x * kPi / 2); };
+            curve = [=] (float x) { return (float) std::sin (x * kPi / 2); };
         }
         break;
 
         case kEaseInOutSine:
         {
-            curve = [=] (float x) { return -(std::cosf (kPi * x) - 1) / 2; };
+            curve = [=] (float x) { return -((float) std::cos (kPi * x) - 1) / 2; };
         }
         break;
 

--- a/Source/friz/curves/parametric.cpp
+++ b/Source/friz/curves/parametric.cpp
@@ -90,7 +90,7 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
         case kEaseInOutQuad:
         {
             curve = [] (float x)
-            { return (x < 0.5f) ? (2 * x * x) : (1 - std::powf (-2 * x + 2, 2) / 2); };
+            { return (x < 0.5f) ? (2 * x * x) : (1 - (float) std::pow (-2 * x + 2, 2) / 2); };
         }
         break;
 
@@ -102,14 +102,14 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
 
         case kEaseOutCubic:
         {
-            curve = [] (float x) { return 1 - std::powf (1 - x, 3); };
+            curve = [] (float x) { return 1 - (float) std::pow (1 - x, 3); };
         }
         break;
 
         case kEaseInOutCubic:
         {
             curve = [] (float x)
-            { return (x < 0.5f) ? 4 * x * x * x : 1 - std::powf (-2 * x + 2, 3) / 2; };
+            { return (x < 0.5f) ? 4 * x * x * x : 1 - (float) std::pow (-2 * x + 2, 3) / 2; };
         }
         break;
 
@@ -121,13 +121,13 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
 
         case kEaseOutQuartic:
         {
-            curve = [] (float x) { return 1 - std::powf (1 - x, 4); };
+            curve = [] (float x) { return 1 - (float) std::pow (1 - x, 4); };
         }
         break;
         case kEaseInOutQuartic:
         {
             curve = [] (float x) {
-                return (x < 0.5f) ? 8 * x * x * x * x : 1 - std::powf (-2 * x + 2, 4) / 2;
+                return (x < 0.5f) ? 8 * x * x * x * x : 1 - (float) std::pow (-2 * x + 2, 4) / 2;
             };
         }
         break;
@@ -139,7 +139,7 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
 
         case kEaseOutQuintic:
         {
-            curve = [] (float x) { return 1 - std::powf (1 - x, 5); };
+            curve = [] (float x) { return 1 - (float) std::pow (1 - x, 5); };
         }
         break;
 
@@ -147,21 +147,21 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
         {
             curve = [] (float x) {
                 return (x < 0.5f) ? 16 * x * x * x * x * x
-                                  : 1 - std::powf (-2 * x + 2, 5) / 2;
+                                  : 1 - (float) std::pow (-2 * x + 2, 5) / 2;
             };
         }
         break;
         case kEaseInExpo:
         {
             curve = [=] (float x)
-            { return (x < kZeroIsh) ? 0.f : std::powf (2, 10 * x - 10); };
+            { return (x < kZeroIsh) ? 0.f : (float) std::pow (2, 10 * x - 10); };
         }
         break;
 
         case kEaseOutExpo:
         {
             curve = [=] (float x)
-            { return (x > kOneIsh) ? 1.f : 1 - std::powf (2, -10 * x); };
+            { return (x > kOneIsh) ? 1.f : 1 - (float) std::pow (2, -10 * x); };
         }
         break;
 
@@ -179,21 +179,21 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
                 }
                 else if (x < 0.5f)
                 {
-                    return std::powf (2, 20 * x - 10) / 2;
+                    return (float) std::pow (2, 20 * x - 10) / 2;
                 }
-                return (2 - std::powf (2, -20 * x + 10)) / 2;
+                return (2 - (float) std::pow (2, -20 * x + 10)) / 2;
             };
         }
         break;
         case kEaseInCirc:
         {
-            curve = [] (float x) { return 1 - std::sqrt (1 - std::powf (x, 2)); };
+            curve = [] (float x) { return 1 - std::sqrt (1 - (float) std::pow (x, 2)); };
         }
         break;
 
         case kEaseOutCirc:
         {
-            curve = [] (float x) { return std::sqrt (1 - std::powf (x - 1, 2)); };
+            curve = [] (float x) { return std::sqrt (1 - (float) std::pow (x - 1, 2)); };
         }
         break;
 
@@ -203,9 +203,9 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
             {
                 if (x < 0.5f)
                 {
-                    return (1 - std::sqrt (1 - std::powf (2 * x, 2))) / 2;
+                    return (1 - std::sqrt (1 - (float) std::pow (2 * x, 2))) / 2;
                 }
-                return 0.5f * std::sqrt (1 - std::powf (-2 * x + 2, 2)) + 1;
+                return 0.5f * std::sqrt (1 - (float) std::pow (-2 * x + 2, 2)) + 1;
             };
         }
         break;
@@ -219,7 +219,7 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
         case kEaseOutBack:
         {
             curve = [=] (float x)
-            { return 1 + kC3 * std::powf (x - 1, 3) + kC1 * std::powf (x - 1, 2); };
+            { return 1 + kC3 * (float) std::pow (x - 1, 3) + kC1 * (float) std::pow (x - 1, 2); };
         }
         break;
 
@@ -229,10 +229,10 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
             {
                 if (x < 0.5f)
                 {
-                    return 0.5f * (std::powf (2 * x, 2) * ((kC2 + 1) * 2 * x - kC2));
+                    return 0.5f * ((float) std::pow (2 * x, 2) * ((kC2 + 1) * 2 * x - kC2));
                 }
                 return 0.5f *
-                       (std::powf (2 * x - 2, 2) * ((kC2 + 1) * (x * 2 - 2) + kC2) + 2);
+                       ((float) std::pow (2 * x - 2, 2) * ((kC2 + 1) * (x * 2 - 2) + kC2) + 2);
             };
         }
         break;
@@ -251,7 +251,7 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
                 }
                 else
                 {
-                    return -std::powf (2, 10 * x - 10) *
+                    return -(float) std::pow (2, 10 * x - 10) *
                            std::sin ((x * 10 - 10.75f) * kC4);
                 }
             };
@@ -271,7 +271,7 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
                 }
                 else
                 {
-                    return std::powf (2, -10 * x) * std::sin ((x * 10 - 0.75f) * kC4) + 1;
+                    return (float) std::pow (2, -10 * x) * std::sin ((x * 10 - 0.75f) * kC4) + 1;
                 }
             };
         }
@@ -291,12 +291,12 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
                 }
                 else if (x < 0.5f)
                 {
-                    return 0.5f * -(std::powf (2, 20 * x - 10) *
+                    return 0.5f * -((float) std::pow (2, 20 * x - 10) *
                                     std::sin ((20 * x - 11.125f) * kC5));
                 }
                 else
                 {
-                    return 0.5f * (std::powf (2, -20 * x + 10) *
+                    return 0.5f * ((float) std::pow (2, -20 * x + 10) *
                                    std::sin (20 * x - 11.125f)) +
                            1;
                 }


### PR DESCRIPTION
Resolves #11 

Hey Brett,

I'm building and running tests on GitHub Actions Linux, [but `powf`/ `sinf` / `cosf` aren't  implemented by gcc](https://stackoverflow.com/questions/56417980/cosf-sinf-etc-are-not-in-std), despite them being in the C++17 standard. 

Instead the compiler seems to detect `pow` usage and use `powf` builtins under the hood for float values, which is awkward...

Anyway, not sure you'll love this implementation, but essentially `pow` returns a double which I then narrow to a float. 

Let me know if you'd prefer another solution!  