### PR TITLE
Fix warnings

### DIFF
--- a/Source/friz/control/animation.h
+++ b/Source/friz/control/animation.h
@@ -189,9 +189,9 @@ public:
      * @param sources List of animated value objects.
      * @param id
      */
-    Animation (SourceList&& sources, int id = 0)
+    Animation (SourceList&& sources_, int id = 0)
     : AnimationType { id }
-    , sources { std::move (sources) }
+    , sources { std::move (sources_) }
     {
     }
 

--- a/Source/friz/control/animator.cpp
+++ b/Source/friz/control/animator.cpp
@@ -76,7 +76,7 @@ void Animator::gotoTime (juce::int64 timeInMs)
     juce::ScopedLock lock { mutex };
 
     // for (auto& animation : animations)
-    for (int i { 0 }; i < animations.size (); ++i)
+    for (size_t i { 0 }; i < animations.size (); ++i)
     {
         auto& animation { animations[i] };
         if (animation.get () != nullptr)
@@ -185,7 +185,7 @@ bool Animator::updateTarget (int id, int valueIndex, float newTarget)
     {
         for (auto* animation : foundAnimations)
         {
-            auto* value { animation->getValue (valueIndex) };
+            auto* value { animation->getValue (static_cast<size_t> (valueIndex)) };
             if (value)
                 value->updateTarget (newTarget);
         }

--- a/Source/friz/control/chain.h
+++ b/Source/friz/control/chain.h
@@ -40,18 +40,15 @@ namespace friz
 class Chain : public AnimationType
 {
 public:
-    Chain (int id = 0)
-    : AnimationType (id)
-    {
-    }
+    Chain (int id = 0) : AnimationType (id) {}
 
-    bool isFinished () override { return (currentEffect >= sequence.size ()); }
+    bool isFinished() override { return (currentEffect >= static_cast<int> (sequence.size())); }
 
-    bool isReady () const override
+    bool isReady() const override
     {
         for (const auto& effect : sequence)
         {
-            if ((nullptr == effect) || (!effect->isReady ()))
+            if ((nullptr == effect) || (! effect->isReady()))
                 return false;
         }
         return true;
@@ -65,15 +62,15 @@ public:
             if (AnimationType::Status::finished == effect->gotoTime (timeInMs))
                 ++currentEffect;
 
-            return isFinished () ? AnimationType::Status::finished
-                                 : AnimationType::Status::processing;
+            return isFinished() ? AnimationType::Status::finished
+                                : AnimationType::Status::processing;
         }
         return AnimationType::Status::finished;
     }
 
     void cancel (bool moveToEndPosition) override
     {
-        currentEffect = static_cast<int> (sequence.size () - 1);
+        currentEffect = static_cast<int> (sequence.size() - 1);
         if (moveToEndPosition)
         {
             auto lastEffectPtr = getEffect (currentEffect);
@@ -103,7 +100,7 @@ private:
     AnimationType* getEffect (int index)
     {
         if (juce::isPositiveAndBelow (index, sequence.size ()))
-            return sequence[index].get ();
+            return sequence[static_cast<size_t> (index)].get ();
 
         jassertfalse;
         return nullptr;

--- a/Source/friz/control/controller.h
+++ b/Source/friz/control/controller.h
@@ -71,7 +71,7 @@ private:
     /// @brief  keep a running sum of intervals so we can just divide.
     std::atomic<int> sum { 0 };
     std::atomic<int> updateCount { 0 };
-    int index { 0 };
+    size_t index { 0 };
 };
 
 class Controller

--- a/Source/friz/curves/animatedValue.h
+++ b/Source/friz/curves/animatedValue.h
@@ -43,7 +43,7 @@ public:
     , endVal { endVal_ }
     , currentVal { startVal_ } {
 
-    };
+    }
 
     virtual ~AnimatedValue () = default;
 

--- a/Source/friz/curves/animatedValue.h
+++ b/Source/friz/curves/animatedValue.h
@@ -120,9 +120,9 @@ protected:
 class ToleranceValue : public AnimatedValue
 {
 public:
-    ToleranceValue (float startVal, float endVal, float tolerance)
-    : AnimatedValue { startVal, endVal }
-    , tolerance { tolerance }
+    ToleranceValue (float startVal_, float endVal_, float tolerance_)
+    : AnimatedValue { startVal_, endVal_ }
+    , tolerance { tolerance_ }
     {
     }
 
@@ -193,8 +193,8 @@ protected:
 class TimedValue : public AnimatedValue
 {
 public:
-    TimedValue (float startVal, float endVal, int duration_)
-    : AnimatedValue { startVal, endVal }
+    TimedValue (float startVal_, float endVal_, int duration_)
+    : AnimatedValue { startVal_, endVal_ }
     , duration { duration_ }
     {
     }

--- a/Source/friz/curves/constant.cpp
+++ b/Source/friz/curves/constant.cpp
@@ -24,13 +24,13 @@
 namespace friz
 {
 
-Constant::Constant (float value, int duration)
-: TimedValue (value, value, duration)
+Constant::Constant (float value, int duration_)
+: TimedValue (value, value, duration_)
 {
 }
 
-Constant::Constant (float /*startVal*/, float endVal_, int duration)
-: Constant (endVal_, duration)
+Constant::Constant (float /*startVal*/, float endVal_, int duration_)
+: Constant (endVal_, duration_)
 {
 }
 

--- a/Source/friz/curves/easing.cpp
+++ b/Source/friz/curves/easing.cpp
@@ -25,8 +25,8 @@
 namespace friz
 {
 
-EasingCurve::EasingCurve (float startVal, float endVal, float tolerance, float slewRate_)
-: ToleranceValue (startVal, endVal, tolerance)
+EasingCurve::EasingCurve (float startVal_, float endVal_, float tolerance_, float slewRate_)
+: ToleranceValue (startVal_, endVal_, tolerance_)
 , slewRate (slewRate_)
 {
 }

--- a/Source/friz/curves/easing.cpp
+++ b/Source/friz/curves/easing.cpp
@@ -31,8 +31,8 @@ EasingCurve::EasingCurve (float startVal_, float endVal_, float tolerance_, floa
 {
 }
 
-EaseIn::EaseIn (float startVal, float endVal, float tolerance, float slewRate)
-: EasingCurve (startVal, endVal, tolerance, slewRate)
+EaseIn::EaseIn (float startVal_, float endVal_, float tolerance_, float slewRate_)
+: EasingCurve (startVal_, endVal_, tolerance_, slewRate_)
 {
     jassert (slewRate < 1.f);
 }
@@ -42,8 +42,8 @@ float EaseIn::generateNextValue ()
     return currentVal + slewRate * (endVal - currentVal);
 }
 
-EaseOut::EaseOut (float startVal, float endVal, float tolerance, float slewRate)
-: EasingCurve (startVal, endVal, tolerance, slewRate)
+EaseOut::EaseOut (float startVal_, float endVal_, float tolerance_, float slewRate_)
+: EasingCurve (startVal_, endVal_, tolerance_, slewRate_)
 , currentRate { 0.01f }
 {
     jassert (slewRate > 1.f);

--- a/Source/friz/curves/easing.h
+++ b/Source/friz/curves/easing.h
@@ -66,8 +66,8 @@ private:
 class SmoothedValue : public EaseIn
 {
 public:
-    SmoothedValue (float startVal, float endVal, float tolerance, float slewRate)
-    : EaseIn (startVal, endVal, tolerance, slewRate)
+    SmoothedValue (float startVal_, float endVal_, float tolerance_, float slewRate_)
+    : EaseIn (startVal_, endVal_, tolerance_, slewRate_)
     {
     }
 

--- a/Source/friz/curves/linear.cpp
+++ b/Source/friz/curves/linear.cpp
@@ -24,8 +24,8 @@
 namespace friz
 {
 
-Linear::Linear (float startVal, float endVal, int duration)
-: TimedValue (startVal, endVal, duration)
+Linear::Linear (float startVal_, float endVal_, int duration_)
+: TimedValue (startVal_, endVal_, duration_)
 {
     jassert (duration > 0);
 }

--- a/Source/friz/curves/parametric.cpp
+++ b/Source/friz/curves/parametric.cpp
@@ -69,8 +69,8 @@ float easeInBounce (float x)
 namespace friz
 {
 
-Parametric::Parametric (CurveType type, float startVal, float endVal, int duration)
-: Parametric (startVal, endVal, duration, type)
+Parametric::Parametric (CurveType type, float startVal_, float endVal_, int duration_)
+: Parametric (startVal_, endVal_, duration_, type)
 {
 }
 

--- a/Source/friz/curves/parametric.cpp
+++ b/Source/friz/curves/parametric.cpp
@@ -74,8 +74,8 @@ Parametric::Parametric (CurveType type, float startVal, float endVal, int durati
 {
 }
 
-Parametric::Parametric (float startVal, float endVal, int duration, CurveType type)
-: TimedValue (startVal, endVal, duration)
+Parametric::Parametric (float startVal_, float endVal_, int duration_, CurveType type)
+: TimedValue (startVal_, endVal_, duration_)
 {
     switch (type)
     {

--- a/Source/friz/curves/sinusoid.h
+++ b/Source/friz/curves/sinusoid.h
@@ -46,8 +46,8 @@ public:
      * @param endPhase   end phase, typically 0..2pi.
      * @param duration   duration in milliseconds.
      */
-    Sinusoid (float startPhase_, float endPhase_, int duration)
-    : TimedValue (startPhase_, endPhase_, duration)
+    Sinusoid (float startPhase_, float endPhase_, int duration_)
+    : TimedValue (startPhase_, endPhase_, duration_)
     , startPhase { startPhase_ }
     , endPhase { endPhase_ }
     {
@@ -88,9 +88,9 @@ public:
      * @param duration  duration in frames.
      */
 
-    Sinusoid (int startQuad, int endQuad, int duration)
+    Sinusoid (int startQuad, int endQuad, int duration_)
     : Sinusoid (startQuad * juce::MathConstants<float>::halfPi,
-                endQuad * juce::MathConstants<float>::halfPi, duration)
+                endQuad * juce::MathConstants<float>::halfPi, duration_)
     {
     }
 

--- a/Source/friz/curves/spring.cpp
+++ b/Source/friz/curves/spring.cpp
@@ -23,9 +23,9 @@
 
 namespace friz
 {
-Spring::Spring (float startVal, float endVal, float tolerance, float accel,
+Spring::Spring (float startVal_, float endVal_, float tolerance_, float accel,
                 float damping_)
-: ToleranceValue (startVal, endVal, tolerance)
+: ToleranceValue (startVal_, endVal_, tolerance_)
 , acceleration (accel)
 , damping (damping_)
 , velocity (0)

--- a/Source/friz/curves/spring.cpp
+++ b/Source/friz/curves/spring.cpp
@@ -26,7 +26,6 @@ namespace friz
 Spring::Spring (float startVal, float endVal, float tolerance, float accel,
                 float damping_)
 : ToleranceValue (startVal, endVal, tolerance)
-, startAcceleration (accel)
 , acceleration (accel)
 , damping (damping_)
 , velocity (0)

--- a/Source/friz/curves/spring.h
+++ b/Source/friz/curves/spring.h
@@ -53,9 +53,6 @@ private:
     float generateNextValue () override;
 
 private:
-    /// The initial acceleration for this value.
-    float startAcceleration;
-
     /// When we're in a damping state, the acceleration will change.
     float acceleration;
 


### PR DESCRIPTION
Hi and thanks for this great library!

Building on mac, I ran into some warnings - mainly shadowing and sign conversions, so I made some changes to resolve these.
Most of the changes should be pretty straight forward, but I'm a bit unsure about that `currentEffect` member in `Chain`. Changing the type to `size_t` instead of `int` could resolve the issues, but it's not private, so for now I just went with some `static_cast`s.

Hope this is helpful!